### PR TITLE
FIX didn't save database after item more than backpack.

### DIFF
--- a/src/at/pcgamingfreaks/MinePacks/Backpack.java
+++ b/src/at/pcgamingfreaks/MinePacks/Backpack.java
@@ -103,6 +103,7 @@ public class Backpack implements InventoryHolder
 						if (i != null)
 						{
 							player.getWorld().dropItemNaturally(player.getLocation(), i);
+                            hasChanged = true;
 						}
 					}
 				}


### PR DESCRIPTION
fix duplicate item bug.
when you have bigger backpack
full backpack.
and change to smaller backpack.

open backpack, 
item more than size will drops
don't move anything
and exit game, rejoin, 
open backpack,
items will drop again.

you can duplicate those infinity.
this can fix this problem.