### PR TITLE
Pickup item collection toggle command

### DIFF
--- a/Minepacks/resources/config.yml
+++ b/Minepacks/resources/config.yml
@@ -50,12 +50,15 @@ Cooldown:
 
 # Controls for the auto pickup on full inventory function
 FullInventory:
-  # If items should be collected to the backpack if the players inventory is full
+  # If items should be collected to the backpack if the players inventory is full.
+  # This is also the default if 'IsToggleAllowed' is enabled.
   CollectItems: false
   # Interval in seconds how often items around the player should be collected, increase it if it lags the server
   CheckInterval: 1
   # Radius in which items get collected, in meter/blocks, allow decimals
   CollectRadius: 1.5
+  # If this feature may be toggled.
+  IsToggleAllowed: false
 
 
 # Database settings

--- a/Minepacks/resources/lang/en.yml
+++ b/Minepacks/resources/lang/en.yml
@@ -60,6 +60,10 @@ Language:
       Cleared: "Inventory cleared."
       ClearedOther: "{DisplayName}'s&r inventory has been cleared."
       ClearedOtherTarget: "Your inventory has been cleared by {DisplayName}&r."
+    Pickup:
+      NotEnabled: "&cNot allowed. &7This server doesn't allow you to change the toggle item collection."
+      ToggleOn: "&7Automatic item collection has been toggled &aON&7."
+      ToggleOff: "&7Automatic item collection has been toggled &cOFF&7."
   Commands:
     HelpFormat: "[\"\",{\"text\":\"/{MainCommand} {SubCommand} {Parameters}\",\"clickEvent\":{\"action\":\"suggest_command\",\"value\":\"/{MainCommand} {SubCommand}\"}},{\"text\":\" - \",\"color\":\"white\"},{\"text\":\"{Description}\",\"color\":\"aqua\"}]"
     PlayerNameVariable: "player_name"
@@ -78,6 +82,7 @@ Language:
       RestoreList: "Lists all available backups."
       Help: "Shows all available commands and their description."
       Migrate: "Migrates the used database from one type to another."
+      Pickup: "Toggle the state of the automatic pickup when the inventory is full."
 
 Command:
   Backpack:
@@ -110,6 +115,9 @@ Command:
     - clear
     - inventoryclear
     - clean
+  Pickup:
+    - pickup
+    - toggle
 
 # Will be shown in the console during startup
 LanguageName: "english"

--- a/Minepacks/resources/plugin.yml
+++ b/Minepacks/resources/plugin.yml
@@ -84,6 +84,9 @@ permissions:
   backpack.fullpickup:
     description: Allows the player to automatically pick up items when their inventory is full (function needs to be enabled in the config)
     defaut: true
+  backpack.fullpickup.toggle:
+    description: Allows the player to toggle the automatic pickup feature.
+    default: true
   backpack.clean.other:
     description: Allows the player to clean other players backpacks.
     default: op

--- a/Minepacks/resources/plugin.yml
+++ b/Minepacks/resources/plugin.yml
@@ -17,6 +17,7 @@ permissions:
       backpack.keepOnDeath: true
       backpack.clean: true
       backpack.fullpickup: true
+      backpack.fullpickup.toggle: true
       backpack.bypass: true
       backpack.admin: true
   backpack.disable:

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Command/CommandManager.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Command/CommandManager.java
@@ -81,6 +81,7 @@ public class CommandManager extends CommandExecutorWithSubCommandsGeneric<Minepa
 		registerSubCommand(new RestoreCommand(plugin));
 		registerSubCommand(new MigrateCommand(plugin));
 		registerSubCommand(new VersionCommand(plugin));
+		registerSubCommand(new PickupCommand(plugin));
 		registerSubCommand(new DebugCommand(plugin));
 		registerSubCommand(new HelpCommand(plugin, commands, this));
 	}

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Command/PickupCommand.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Command/PickupCommand.java
@@ -1,0 +1,55 @@
+package at.pcgamingfreaks.Minepacks.Bukkit.Command;
+
+import at.pcgamingfreaks.Bukkit.Message.Message;
+import at.pcgamingfreaks.Minepacks.Bukkit.API.MinepacksCommand;
+import at.pcgamingfreaks.Minepacks.Bukkit.ItemsCollector;
+import at.pcgamingfreaks.Minepacks.Bukkit.Minepacks;
+import at.pcgamingfreaks.Minepacks.Bukkit.Permissions;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class PickupCommand extends MinepacksCommand {
+
+    private final Minepacks plugin;
+    private final Message featureNotEnabled;
+
+    private final Message toggleOn;
+    private final Message toggleOff;
+
+    public PickupCommand(Minepacks plugin) {
+        super(plugin, "pickup", plugin.getLanguage().getTranslated("Commands.Description.Pickup"), Permissions.PICKUP_TOGGLE, true, plugin.getLanguage().getCommandAliases("Pickup"));
+
+        this.plugin = plugin;
+        featureNotEnabled       = plugin.getLanguage().getMessage("Ingame.Pickup.NotEnabled");
+        toggleOn                = plugin.getLanguage().getMessage("Ingame.Pickup.ToggleOn");
+        toggleOff                = plugin.getLanguage().getMessage("Ingame.Pickup.ToggleOff");
+    }
+
+    @Override
+    public void execute(@NotNull CommandSender sender, @NotNull String s, @NotNull String s1, @NotNull String[] args) {
+        Player player = (Player) sender;
+        ItemsCollector collector = plugin.getItemsCollector();
+
+        if (collector == null || !collector.isToggleable()) {
+            featureNotEnabled.send(player);
+            return;
+        }
+
+        boolean isEnabled = collector.toggleState(player.getUniqueId());
+
+        if (isEnabled) {
+            toggleOn.send(player);
+            return;
+        }
+
+        toggleOff.send(player);
+    }
+
+    @Override
+    public List<String> tabComplete(@NotNull CommandSender commandSender, @NotNull String s, @NotNull String s1, @NotNull String[] strings) {
+        return null;
+    }
+}

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Database/Config.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Database/Config.java
@@ -317,6 +317,14 @@ public class Config extends Configuration implements DatabaseConnectionConfigura
 	{
 		return getConfigE().getDouble("FullInventory.CollectRadius", 1.5); // in blocks
 	}
+
+	public boolean isToggleAllowed() {
+		return getConfigE().getBoolean("FullInventory.IsToggleAllowed", false);
+	}
+
+	public boolean isEnabledOnJoin() {
+		return getFullInvCollect();
+	}
 	//endregion
 
 	//region Shulkerboxes

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/ItemsCollector.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/ItemsCollector.java
@@ -72,8 +72,8 @@ public class ItemsCollector extends BukkitRunnable
 		{
 			if(plugin.isDisabled(player) != WorldBlacklistMode.None) return;
 
-			// Check toggle
-			if (!isToggleable || !isPickupEnabled(player.getUniqueId())) return;
+			// If toggle is enabled AND player has been disabled, return.
+			if (isToggleable && !isPickupEnabled(player.getUniqueId())) return;
 
 			// No permission ot use the backpack.
 			if (!player.hasPermission(Permissions.USE)) return;

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Minepacks.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Minepacks.java
@@ -216,7 +216,7 @@ public class Minepacks extends JavaPlugin implements MinepacksPlugin, IPlugin
 		else shortcut = null;
 		if(config.isWorldWhitelistMode()) pluginManager.registerEvents(new WorldBlacklistUpdater(this), this);
 		//endregion
-		if(config.getFullInvCollect()) collector = new ItemsCollector(this);
+		if(config.getFullInvCollect() || config.isToggleAllowed()) collector = new ItemsCollector(this);
 		worldBlacklist = config.getWorldBlacklist();
 		worldBlacklistMode = (worldBlacklist.size() == 0) ? WorldBlacklistMode.None : config.getWorldBlockMode();
 
@@ -400,6 +400,10 @@ public class Minepacks extends JavaPlugin implements MinepacksPlugin, IPlugin
 	{
 		if(shortcut == null) return false;
 		return shortcut.isItemShortcut(itemStack);
+	}
+
+	public ItemsCollector getItemsCollector() {
+		return collector;
 	}
 
 	@Override

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Permissions.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Permissions.java
@@ -25,6 +25,7 @@ public class Permissions
 	public static final String CLEAN = BASE + "clean";
 	public static final String CLEAN_OTHER = BASE + "clean.other";
 	public static final String FULL_PICKUP = BASE + "fullpickup";
+	public static final String PICKUP_TOGGLE = BASE + "fullpickup.toggle";
 	public static final String OTHERS = BASE + "others";
 	public static final String OTHERS_EDIT = BASE + "others.edit";
 	public static final String KEEP_ON_DEATH = BASE + "keepOnDeath";


### PR DESCRIPTION
This PR adds the functionality where people can toggle on/off the automatic pickup feature.

Relevant config section change:
```ylm
# Controls for the auto pickup on full inventory function
FullInventory:
  # If items should be collected to the backpack if the players inventory is full.
  # This is also the default if 'IsToggleAllowed' is enabled.
  CollectItems: false
  # Interval in seconds how often items around the player should be collected, increase it if it lags the server
  CheckInterval: 1
  # Radius in which items get collected, in meter/blocks, allow decimals
  CollectRadius: 1.5
  # If this feature may be toggled.
  IsToggleAllowed: false
```

Permission added:
```ylm
  backpack.fullpickup.toggle:
    description: Allows the player to toggle the automatic pickup feature.
    default: true
```
Either `backpack.fullpickup` or `backpack.fullpickup.toggle` is required for the item collector to work.

Additionally, this PR removes a bit of nested code in the ItemsCollector.
Changes have been tested, but probably require additional testing from someone else.


Kind of out of the blue this PR, but maybe it's of use.