### PR TITLE
Fix duplication exploits, optimize MySQL queries and migration performance

### DIFF
--- a/Minepacks/resources/config.yml
+++ b/Minepacks/resources/config.yml
@@ -88,7 +88,8 @@ Database:
     User: "minecraft"
     Password: "minecraft"
     # The max amount of connections to the database the connection pool will open
-    MaxConnections: 2
+    # Recommended: 8-12 for medium servers (20-50 players), 16-20 for large servers (50+ players)
+    MaxConnections: 10
     # Sets the max lifetime of the connection in seconds. -1 = Default (30min)
     MaxLifetime: -1
     # Sets the idle timeout of the connection in seconds. -1 = Default (15min)

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Command/RestoreCommand.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Command/RestoreCommand.java
@@ -115,6 +115,10 @@ public class RestoreCommand extends MinepacksCommand
 				return;
 			}
 			getMinepacksPlugin().getBackpack(target, backpack -> {
+				if (backpack.isOpen())
+				{
+					((Backpack) backpack).closeAll();
+				}
 				if (backpack.getSize() != items.length)
 				{
 					backpack.clear();

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Command/SortCommand.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Command/SortCommand.java
@@ -43,6 +43,10 @@ public class SortCommand extends MinepacksCommand
 	{
 		final Player player = (Player) commandSender;
 		getMinepacksPlugin().getBackpack(player, backpack -> {
+			if (backpack.isOpen())
+			{
+				((at.pcgamingfreaks.Minepacks.Bukkit.Backpack) backpack).closeAll();
+			}
 			InventoryCompressor compressor = new InventoryCompressor(backpack.getInventory().getContents());
 			if(!compressor.sort().isEmpty())
 			{

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Database/Migration/FilesToSQLMigration.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Database/Migration/FilesToSQLMigration.java
@@ -48,10 +48,13 @@ public class FilesToSQLMigration extends ToSQLMigration
 	{
 		File[] allFiles = saveFolder.listFiles((dir, name) -> name.endsWith(Files.EXT));
 		if(allFiles == null) return null;
+		final int BATCH_SIZE = 100;
 		try(Connection connection = newDb.getConnection(); PreparedStatement statementInsertUser = connection.prepareStatement(queryInsertUsers, PreparedStatement.RETURN_GENERATED_KEYS);
 		    PreparedStatement statementInsertBackpack = connection.prepareStatement(queryInsertBackpacks))
 		{
+			connection.setAutoCommit(false);
 			int migrated = 0;
+			int batchCount = 0;
 			for(File file : allFiles)
 			{
 				String name = file.getName().substring(0, file.getName().length() - Files.EXT.length());
@@ -71,12 +74,23 @@ public class FilesToSQLMigration extends ToSQLMigration
 							statementInsertBackpack.setInt(1, rs.getInt(1));
 							statementInsertBackpack.setBytes(2, data);
 							statementInsertBackpack.setInt(3, version);
-							statementInsertBackpack.executeUpdate();
+							statementInsertBackpack.addBatch();
 							migrated++;
+							batchCount++;
 						}
 					}
 				}
-
+				if(batchCount >= BATCH_SIZE)
+				{
+					statementInsertBackpack.executeBatch();
+					connection.commit();
+					batchCount = 0;
+				}
+			}
+			if(batchCount > 0)
+			{
+				statementInsertBackpack.executeBatch();
+				connection.commit();
 			}
 			return new MigrationResult("Migrated " + migrated + " backpacks from Files to " + newDb.getClass().getSimpleName(), MigrationResult.MigrationResultType.SUCCESS);
 		}

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Database/SQL.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Database/SQL.java
@@ -103,7 +103,7 @@ public abstract class SQL extends Database
 	public void close()
 	{
 		super.close();
-		Utils.blockThread(1); // Give the database some time to perform async operations
+		Utils.blockThread(5); // Give the database enough time to perform async operations
 		dataSource.close();
 	}
 
@@ -133,7 +133,7 @@ public abstract class SQL extends Database
 		querySyncCooldown = "INSERT INTO {TableCooldowns} ({FieldCDPlayer},{FieldCDTime}) SELECT {FieldPlayerID},? FROM {TablePlayers} WHERE {FieldUUID}=? ON DUPLICATE KEY UPDATE {FieldCDTime}=?;";
 		queryUpdatePlayerAdd = "INSERT INTO {TablePlayers} ({FieldName},{FieldUUID}) VALUES (?,?) ON DUPLICATE KEY UPDATE {FieldName}=?;";
 		queryGetPlayerID = "SELECT {FieldPlayerID} FROM {TablePlayers} WHERE {FieldUUID}=?;";
-		queryGetCooldown = "SELECT * FROM {TableCooldowns} WHERE {FieldCDPlayer} IN (SELECT {FieldPlayerID} FROM {TablePlayers} WHERE {FieldUUID}=?);";
+		queryGetCooldown = "SELECT {FieldCDTime} FROM {TableCooldowns} INNER JOIN {TablePlayers} ON {TableCooldowns}.{FieldCDPlayer}={TablePlayers}.{FieldPlayerID} WHERE {FieldUUID}=?;";
 		queryInsertBp = "REPLACE INTO {TableBackpacks} ({FieldBPOwner},{FieldBPITS},{FieldBPVersion}) VALUES (?,?,?);";
 		queryUpdateBp = "UPDATE {TableBackpacks} SET {FieldBPITS}=?,{FieldBPVersion}=?,{FieldBPLastUpdate}={NOW} WHERE {FieldBPOwner}=?;";
 		queryDeleteOldBackpacks = "DELETE FROM {TableBackpacks} WHERE {FieldBPLastUpdate} < DATE('now', '-{VarMaxAge} days')";

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/ItemsCollector.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/ItemsCollector.java
@@ -84,7 +84,7 @@ public class ItemsCollector extends CancellableRunnable {
 
 				// Only check loaded backpacks (loading them would take too much time for a repeating task, the backpack will be loaded async soon enough)
 				Backpack backpack = (Backpack) plugin.getBackpackCachedOnly(player);
-				if (backpack == null) return;
+				if (backpack == null || backpack.isOpen()) return;
 
 				List<Entity> entities = player.getNearbyEntities(radius, radius, radius);
 				for(Entity entity : entities)

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Listener/BackpackEventListener.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Listener/BackpackEventListener.java
@@ -28,6 +28,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 public class BackpackEventListener extends MinepacksListener
@@ -87,6 +88,23 @@ public class BackpackEventListener extends MinepacksListener
 		}
 	}
 	
+	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	public void onDrag(InventoryDragEvent event)
+	{
+		if (event.getInventory() != null && event.getInventory().getHolder() instanceof Backpack && event.getWhoClicked() instanceof Player)
+		{
+			Backpack backpack = (Backpack) event.getInventory().getHolder();
+			if(!backpack.canEdit((Player)event.getWhoClicked()))
+			{
+				event.setCancelled(true);
+			}
+			else
+			{
+				backpack.setChanged();
+			}
+		}
+	}
+
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onPlayerLeaveEvent(PlayerQuitEvent event)
 	{

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Listener/ItemFilter.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Listener/ItemFilter.java
@@ -132,10 +132,18 @@ public class ItemFilter extends MinepacksListener implements at.pcgamingfreaks.M
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	public void onItemDrag(InventoryDragEvent event)
 	{
-		if(event.getInventory().getType() == InventoryType.CHEST && event.getInventory().getHolder() instanceof Backpack && (isItemBlocked(event.getOldCursor()) || isItemBlocked(event.getCursor())) && event.getRawSlots().containsAll(event.getInventorySlots()))
+		if(event.getInventory().getType() == InventoryType.CHEST && event.getInventory().getHolder() instanceof Backpack && (isItemBlocked(event.getOldCursor()) || isItemBlocked(event.getCursor())))
 		{
-			sendNotAllowedMessage((Player) event.getView().getPlayer(), event.getOldCursor());
-			event.setCancelled(true);
+			int topSize = event.getView().getTopInventory().getSize();
+			for(int slot : event.getRawSlots())
+			{
+				if(slot < topSize)
+				{
+					sendNotAllowedMessage((Player) event.getView().getPlayer(), event.getOldCursor());
+					event.setCancelled(true);
+					return;
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

This PR addresses several **item duplication vulnerabilities**, **MySQL performance issues**, and **migration speed** in the Minepacks plugin.

### Duplication Exploit Fixes

- **Add missing `InventoryDragEvent` handler** in `BackpackEventListener`: dragging items into/out of backpacks did not call `setChanged()`, meaning drag-only modifications were never persisted to the database. This also enforces the read-only check for non-editable viewers on drag operations.
- **Fix `ItemFilter` drag bypass**: the previous condition (`getRawSlots().containsAll(getInventorySlots())`) only cancelled drags when **all** raw slots were inside the backpack. A partial drag spanning both the backpack and the player inventory could slip blocked items through the filter. The new logic cancels the event if **any** dragged slot targets the backpack (top inventory).
- **Close open backpacks before `RestoreCommand` and `SortCommand`**: both commands modified the backpack inventory contents without checking if a player currently had it open, causing desynchronized views and potential item duplication. They now call `closeAll()` before applying changes.
- **Skip auto-pickup when backpack is open** in `ItemsCollector`: the repeating collection task was adding items via `backpack.addItems()` even while a player was viewing the inventory, causing UI desynchronization. It now skips collection if `isOpen()` returns true.

### MySQL / Database Optimizations

- **Replace subquery with `INNER JOIN` in cooldown lookup**: changed `SELECT * FROM cooldowns WHERE player_id IN (SELECT player_id FROM players WHERE uuid=?)` to a targeted `SELECT time FROM cooldowns INNER JOIN players ON ... WHERE uuid=?`. This eliminates the subquery overhead and avoids fetching unnecessary columns.
- **Increase shutdown grace period** from 1 second to 5 seconds (`Utils.blockThread`): ensures all pending async database writes complete before the connection pool is closed, reducing the risk of data loss on server shutdown.
- **Increase default `MaxConnections`** from 2 to 10: a pool of 2 connections is easily exhausted on servers with 20+ concurrent players performing async saves, loads, and cooldown checks simultaneously. Added a recommendation comment for server admins.

### Migration Performance

- **Batch inserts in `FilesToSQLMigration`**: replaced individual `executeUpdate()` calls with `addBatch()` / `executeBatch()` with transaction commits every 100 entries. This can improve file-to-SQL migration speed by 10-100x on large datasets.