### PR TITLE
Fix item duplication exploits via drag events, command desync, and auto-pickup

### DIFF
--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Command/RestoreCommand.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Command/RestoreCommand.java
@@ -115,6 +115,10 @@ public class RestoreCommand extends MinepacksCommand
 				return;
 			}
 			getMinepacksPlugin().getBackpack(target, backpack -> {
+				if (backpack.isOpen())
+				{
+					((Backpack) backpack).closeAll();
+				}
 				if (backpack.getSize() != items.length)
 				{
 					backpack.clear();

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Command/SortCommand.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Command/SortCommand.java
@@ -43,6 +43,10 @@ public class SortCommand extends MinepacksCommand
 	{
 		final Player player = (Player) commandSender;
 		getMinepacksPlugin().getBackpack(player, backpack -> {
+			if (backpack.isOpen())
+			{
+				((at.pcgamingfreaks.Minepacks.Bukkit.Backpack) backpack).closeAll();
+			}
 			InventoryCompressor compressor = new InventoryCompressor(backpack.getInventory().getContents());
 			if(!compressor.sort().isEmpty())
 			{

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/ItemsCollector.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/ItemsCollector.java
@@ -84,7 +84,7 @@ public class ItemsCollector extends CancellableRunnable {
 
 				// Only check loaded backpacks (loading them would take too much time for a repeating task, the backpack will be loaded async soon enough)
 				Backpack backpack = (Backpack) plugin.getBackpackCachedOnly(player);
-				if (backpack == null) return;
+				if (backpack == null || backpack.isOpen()) return;
 
 				List<Entity> entities = player.getNearbyEntities(radius, radius, radius);
 				for(Entity entity : entities)

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Listener/BackpackEventListener.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Listener/BackpackEventListener.java
@@ -28,6 +28,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 public class BackpackEventListener extends MinepacksListener
@@ -87,6 +88,23 @@ public class BackpackEventListener extends MinepacksListener
 		}
 	}
 	
+	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	public void onDrag(InventoryDragEvent event)
+	{
+		if (event.getInventory() != null && event.getInventory().getHolder() instanceof Backpack && event.getWhoClicked() instanceof Player)
+		{
+			Backpack backpack = (Backpack) event.getInventory().getHolder();
+			if(!backpack.canEdit((Player)event.getWhoClicked()))
+			{
+				event.setCancelled(true);
+			}
+			else
+			{
+				backpack.setChanged();
+			}
+		}
+	}
+
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onPlayerLeaveEvent(PlayerQuitEvent event)
 	{

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Listener/ItemFilter.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Listener/ItemFilter.java
@@ -132,10 +132,18 @@ public class ItemFilter extends MinepacksListener implements at.pcgamingfreaks.M
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	public void onItemDrag(InventoryDragEvent event)
 	{
-		if(event.getInventory().getType() == InventoryType.CHEST && event.getInventory().getHolder() instanceof Backpack && (isItemBlocked(event.getOldCursor()) || isItemBlocked(event.getCursor())) && event.getRawSlots().containsAll(event.getInventorySlots()))
+		if(event.getInventory().getType() == InventoryType.CHEST && event.getInventory().getHolder() instanceof Backpack && (isItemBlocked(event.getOldCursor()) || isItemBlocked(event.getCursor())))
 		{
-			sendNotAllowedMessage((Player) event.getView().getPlayer(), event.getOldCursor());
-			event.setCancelled(true);
+			int topSize = event.getView().getTopInventory().getSize();
+			for(int slot : event.getRawSlots())
+			{
+				if(slot < topSize)
+				{
+					sendNotAllowedMessage((Player) event.getView().getPlayer(), event.getOldCursor());
+					event.setCancelled(true);
+					return;
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes several item duplication vectors discovered during a full plugin audit.

### Changes

- **Add missing `InventoryDragEvent` handler** in `BackpackEventListener`: dragging items into/out of backpacks did not call `setChanged()`, so drag-only modifications were never persisted to the database. This also enforces the read-only check (`canEdit()`) for non-editable viewers on drag operations.

- **Fix `ItemFilter` drag bypass**: the previous condition (`getRawSlots().containsAll(getInventorySlots())`) only cancelled drags when **all** raw slots targeted the backpack. A partial drag spanning both the backpack and the player inventory could slip blocked items through the filter. The new logic cancels the event if **any** dragged raw slot falls within the top (backpack) inventory.

- **Close open backpacks before `RestoreCommand` and `SortCommand`**: both commands modified backpack contents without checking if a player currently had the inventory open, causing desynchronized views and potential item duplication. They now call `closeAll()` before applying changes.

- **Skip auto-pickup when backpack is open** in `ItemsCollector`: the repeating collection task added items via `backpack.addItems()` even while a player was viewing the inventory, causing UI desync. It now skips collection when `isOpen()` returns true.