### PR TITLE
Optimize MySQL cooldown query and connection pool defaults

### DIFF
--- a/Minepacks/resources/config.yml
+++ b/Minepacks/resources/config.yml
@@ -88,7 +88,8 @@ Database:
     User: "minecraft"
     Password: "minecraft"
     # The max amount of connections to the database the connection pool will open
-    MaxConnections: 2
+    # Recommended: 8-12 for medium servers (20-50 players), 16-20 for large servers (50+ players)
+    MaxConnections: 10
     # Sets the max lifetime of the connection in seconds. -1 = Default (30min)
     MaxLifetime: -1
     # Sets the idle timeout of the connection in seconds. -1 = Default (15min)

--- a/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Database/SQL.java
+++ b/Minepacks/src/at/pcgamingfreaks/Minepacks/Bukkit/Database/SQL.java
@@ -103,7 +103,7 @@ public abstract class SQL extends Database
 	public void close()
 	{
 		super.close();
-		Utils.blockThread(1); // Give the database some time to perform async operations
+		Utils.blockThread(5); // Give the database enough time to perform async operations
 		dataSource.close();
 	}
 
@@ -133,7 +133,7 @@ public abstract class SQL extends Database
 		querySyncCooldown = "INSERT INTO {TableCooldowns} ({FieldCDPlayer},{FieldCDTime}) SELECT {FieldPlayerID},? FROM {TablePlayers} WHERE {FieldUUID}=? ON DUPLICATE KEY UPDATE {FieldCDTime}=?;";
 		queryUpdatePlayerAdd = "INSERT INTO {TablePlayers} ({FieldName},{FieldUUID}) VALUES (?,?) ON DUPLICATE KEY UPDATE {FieldName}=?;";
 		queryGetPlayerID = "SELECT {FieldPlayerID} FROM {TablePlayers} WHERE {FieldUUID}=?;";
-		queryGetCooldown = "SELECT * FROM {TableCooldowns} WHERE {FieldCDPlayer} IN (SELECT {FieldPlayerID} FROM {TablePlayers} WHERE {FieldUUID}=?);";
+		queryGetCooldown = "SELECT {FieldCDTime} FROM {TableCooldowns} INNER JOIN {TablePlayers} ON {TableCooldowns}.{FieldCDPlayer}={TablePlayers}.{FieldPlayerID} WHERE {FieldUUID}=?;";
 		queryInsertBp = "REPLACE INTO {TableBackpacks} ({FieldBPOwner},{FieldBPITS},{FieldBPVersion}) VALUES (?,?,?);";
 		queryUpdateBp = "UPDATE {TableBackpacks} SET {FieldBPITS}=?,{FieldBPVersion}=?,{FieldBPLastUpdate}={NOW} WHERE {FieldBPOwner}=?;";
 		queryDeleteOldBackpacks = "DELETE FROM {TableBackpacks} WHERE {FieldBPLastUpdate} < DATE('now', '-{VarMaxAge} days')";


### PR DESCRIPTION
## Summary

Improves MySQL performance for servers with concurrent players.

### Changes

- **Replace subquery with `INNER JOIN` in cooldown lookup**: changed `SELECT * FROM cooldowns WHERE player_id IN (SELECT player_id FROM players WHERE uuid=?)` to `SELECT time FROM cooldowns INNER JOIN players ON ... WHERE uuid=?`. This eliminates the subquery overhead and avoids fetching unnecessary columns (`SELECT *` → `SELECT time`).

- **Increase shutdown grace period** from 1 second to 5 seconds: the previous 1-second `Utils.blockThread()` was too short for servers with many players logging out simultaneously. Pending async database writes could be lost if the connection pool closed before they completed.

- **Increase default `MaxConnections`** from 2 to 10 in `config.yml`: a pool of 2 connections is easily exhausted on servers with 20+ concurrent players performing async saves, loads, and cooldown checks simultaneously. Also added a comment recommending values for different server sizes.