### PR TITLE
Fix backpack.fullpickup "default" permission

### DIFF
--- a/Minepacks/resources/plugin.yml
+++ b/Minepacks/resources/plugin.yml
@@ -85,7 +85,7 @@ permissions:
     default: false
   backpack.fullpickup:
     description: Allows the player to automatically pick up items when their inventory is full (function needs to be enabled in the config)
-    defaut: true
+    default: true
   backpack.fullpickup.toggle:
     description: Allows the player to toggle the automatic pickup feature.
     default: true


### PR DESCRIPTION
Fix backpack.fullpickup permission, set "default" instead "defaut"